### PR TITLE
Use default Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/connecteurs/alpine:v3.19.1
+FROM alpine:3.19.1
 
 WORKDIR /app
 VOLUME /app


### PR DESCRIPTION
This make it use the default Alpine Docker image as base instead of the custom one.